### PR TITLE
fix: package.json path error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // const pluginName = 'QiankunDevConfigPlugin';
 
 import webpack, { Compiler, /*Entry*/ } from 'webpack'
-import { join } from 'path';
+import path from 'path';
 import fs from 'fs'
 import HtmlWebpackPluginType from 'html-webpack-plugin'
 
@@ -36,7 +36,7 @@ class QiankunDevConfigPlugin {
 
         // get app name configuration 
         let appName: string;
-        const pkgPath = join(compiler.context, 'package.json');
+        const pkgPath = path.resolve(process.cwd(), 'package.json');
         if (this.options.appName) {
             appName = this.options.appName;
         } else if (fs.existsSync(pkgPath)) {


### PR DESCRIPTION
`package.json` 可能不在 `context`里，比如直接指定 `context` 为 `src` ，这样 `src/package.json` 就异常了，感觉是不是 `cwd()` 会稳点

